### PR TITLE
[refactoring] Add Track and Tracklist modules

### DIFF
--- a/elm-client/src/Api.elm
+++ b/elm-client/src/Api.elm
@@ -5,11 +5,11 @@ import Http
 import Json.Decode exposing (field)
 import Json.Decode.Extra exposing ((|:))
 import Json.Encode
-import Model exposing (Track, StreamingInfo(..), TrackId)
 import Radio.Model exposing (ConnectedUser)
 import Radio.SignupForm exposing (Field(..))
 import Radio.LoginForm as LoginForm
 import Task exposing (Task)
+import Track exposing (Track, TrackId, StreamingInfo(..))
 
 
 fetchPlaylist : Maybe String -> String -> Json.Decode.Decoder Track -> Http.Request ( List Track, Maybe String )

--- a/elm-client/src/Feed/Main.elm
+++ b/elm-client/src/Feed/Main.elm
@@ -12,6 +12,7 @@ import Player
 import PlayerEngine
 import Task
 import Time exposing (Time)
+import Tracklist
 
 
 main : Program String Model Msg
@@ -37,7 +38,7 @@ route location =
 
 init : String -> Location -> ( Model, Cmd Msg )
 init soundcloudClientId location =
-    ( { tracks = Dict.empty
+    ( { tracks = Tracklist.empty
       , playlists = playlists
       , playing = False
       , currentPage = route location

--- a/elm-client/src/Feed/Model.elm
+++ b/elm-client/src/Feed/Model.elm
@@ -5,11 +5,13 @@ import Date exposing (Date)
 import Dict exposing (Dict)
 import Player exposing (Player)
 import Time exposing (Time)
-import Model exposing (Track, TrackId, NavigationItem)
+import Model exposing (NavigationItem)
+import Track exposing (Track, TrackId)
+import Tracklist exposing (Tracklist)
 
 
 type alias Model =
-    { tracks : Dict TrackId Track
+    { tracks : Tracklist
     , playlists : List Playlist
     , playing : Bool
     , currentPage : Page
@@ -64,4 +66,4 @@ currentPlaylist model =
 currentTrack : Model -> Maybe Track
 currentTrack model =
     Player.currentTrack model.player
-        |> Maybe.andThen ((flip Dict.get) model.tracks)
+        |> Maybe.andThen ((flip Tracklist.get) model.tracks)

--- a/elm-client/src/Feed/View.elm
+++ b/elm-client/src/Feed/View.elm
@@ -8,10 +8,11 @@ import Html exposing (Html, a, nav, li, ul, text, div, img, input, label, form, 
 import Html.Attributes exposing (class, classList, href, src, style, value, id, type_)
 import Html.Events exposing (onClick, onWithOptions, onInput)
 import Json.Decode
-import Model exposing (Track, TrackId)
 import Player
 import Time exposing (Time)
 import TimeAgo exposing (timeAgo)
+import Track exposing (Track, TrackId)
+import Tracklist exposing (Tracklist)
 import View
 
 
@@ -77,10 +78,10 @@ view model =
         ]
 
 
-viewCustomQueue : Dict TrackId Track -> List TrackId -> Html Msg
+viewCustomQueue : Tracklist -> List TrackId -> Html Msg
 viewCustomQueue tracks queue =
-    queue
-        |> List.filterMap (\trackId -> Dict.get trackId tracks)
+    tracks
+        |> Tracklist.getTracks queue
         |> List.indexedMap (viewCustomPlaylistItem)
         |> div [ class "custom-queue" ]
 
@@ -100,12 +101,11 @@ viewCustomPlaylistItem position track =
         ]
 
 
-viewPlaylist : Maybe Time -> Dict TrackId Track -> Playlist -> List TrackId -> Html Msg
+viewPlaylist : Maybe Time -> Tracklist -> Playlist -> List TrackId -> Html Msg
 viewPlaylist currentTime tracks playlist playlistContent=
     let
         playlistTracks =
-            playlistContent
-                |> List.filterMap (\trackId -> Dict.get trackId tracks)
+            Tracklist.getTracks playlistContent tracks
 
         tracksView =
             List.indexedMap (viewTrack currentTime playlist.id) playlistTracks

--- a/elm-client/src/Model.elm
+++ b/elm-client/src/Model.elm
@@ -1,36 +1,6 @@
 module Model exposing (..)
 
 
-import Date exposing (Date)
-import Youtube exposing (YoutubeId)
-
-
-type alias TrackId = String
-
-
-type alias Track =
-    { id : TrackId
-    , artist : String
-    , artwork_url : String
-    , title : String
-    , streamingInfo: StreamingInfo
-    , sourceUrl : String
-    , createdAt : Date
-    , liked : Bool
-    , progress : Float
-    , currentTime : Float
-    , error : Bool
-    }
-
-
-type StreamingInfo
-    = Soundcloud StreamUrl
-    | Youtube YoutubeId
-
-
-type alias StreamUrl = String
-
-
 type alias NavigationItem page playlist =
     { displayName : String
     , href : String

--- a/elm-client/src/PlayerEngine.elm
+++ b/elm-client/src/PlayerEngine.elm
@@ -4,7 +4,7 @@ port module PlayerEngine exposing
     )
 
 
-import Model exposing (Track, TrackId, StreamingInfo(..))
+import Track exposing (Track, TrackId, StreamingInfo(..))
 import Youtube exposing (YoutubeId)
 
 

--- a/elm-client/src/Radio/Main.elm
+++ b/elm-client/src/Radio/Main.elm
@@ -1,7 +1,6 @@
 port module Radio.Main exposing (..)
 
 import Api
-import Dict exposing (Dict)
 import Json.Decode exposing (field)
 import Http
 import Keyboard
@@ -18,6 +17,7 @@ import Update exposing (andThen, addCmd)
 import Radio.View as View
 import Task
 import Time exposing (Time)
+import Tracklist
 
 
 main : Program String Model Msg
@@ -45,7 +45,7 @@ init initialPayloadJsonString location =
             Json.Decode.decodeString initialPayloadDecoder initialPayloadJsonString
                  |> Result.withDefault Nothing
         model =
-            { tracks = Dict.empty
+            { tracks = Tracklist.empty
             , radio = Radio.Model.emptyPlaylist Radio "/api/playlist"
             , latestTracks = Radio.Model.emptyPlaylist LatestTracks "/api/latest-tracks"
             , likes = Radio.Model.emptyPlaylist Likes "/api/likes"

--- a/elm-client/src/Radio/Model.elm
+++ b/elm-client/src/Radio/Model.elm
@@ -2,16 +2,17 @@ module Radio.Model exposing (..)
 
 
 import Date exposing (Date)
-import Dict exposing (Dict)
 import Player exposing (Player)
 import Radio.LoginForm exposing (LoginForm)
 import Radio.SignupForm exposing (SignupForm)
 import Time exposing (Time)
-import Model exposing (Track, TrackId, NavigationItem)
+import Model exposing (NavigationItem)
+import Track exposing (Track, TrackId)
+import Tracklist exposing (Tracklist)
 
 
 type alias Model =
-    { tracks : Dict TrackId Track
+    { tracks : Tracklist
     , radio : Playlist
     , latestTracks : Playlist
     , likes : Playlist
@@ -74,4 +75,4 @@ type PlaylistId
 currentTrack : Model -> Maybe Track
 currentTrack model =
     Player.currentTrack model.player
-        |> Maybe.andThen ((flip Dict.get) model.tracks)
+        |> Maybe.andThen ((flip Tracklist.get) model.tracks)

--- a/elm-client/src/Radio/View.elm
+++ b/elm-client/src/Radio/View.elm
@@ -1,12 +1,10 @@
 module Radio.View exposing (..)
 
 import Date exposing (Date)
-import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode
-import Model exposing (Track, TrackId, StreamingInfo(..))
 import Radio.Model as Model exposing (Model, Playlist, PlaylistId(..), Page(..), ConnectedUser, PlaylistStatus(..))
 import Radio.SignupView as SignupView
 import Radio.LoginView as LoginView
@@ -16,6 +14,8 @@ import Player
 import Time exposing (Time)
 import TimeAgo exposing (timeAgo)
 import Radio.Update exposing (Msg(..))
+import Track exposing (Track, TrackId, StreamingInfo(..))
+import Tracklist exposing (Tracklist)
 import View
 
 
@@ -44,7 +44,7 @@ view model =
                     let
                         currentRadioTrack =
                             Player.currentTrackOfPlaylist Radio model.player
-                                |> Maybe.andThen ((flip Dict.get) model.tracks)
+                                |> Maybe.andThen ((flip Tracklist.get) model.tracks)
                     in
                         viewRadioTrack currentRadioTrack (Player.currentPlaylist model.player)
                 LatestTracksPage ->
@@ -114,12 +114,11 @@ viewRadioTrack track currentPlaylist =
                 ]
 
 
-viewLatestTracks : Maybe TrackId -> Maybe Time -> Dict TrackId Track -> Playlist -> List TrackId -> Html Msg
+viewLatestTracks : Maybe TrackId -> Maybe Time -> Tracklist -> Playlist -> List TrackId -> Html Msg
 viewLatestTracks currentTrackId currentTime tracks playlist playlistContent=
     let
         playlistTracks =
-            playlistContent
-                |> List.filterMap (\trackId -> Dict.get trackId tracks)
+            Tracklist.getTracks playlistContent tracks
 
         placeholders =
             if playlist.status == Fetching then

--- a/elm-client/src/Soundcloud.elm
+++ b/elm-client/src/Soundcloud.elm
@@ -6,7 +6,7 @@ import Http
 import Json.Decode
 import Json.Decode exposing (field)
 import Json.Decode.Extra exposing ((|:))
-import Model exposing (Track, StreamingInfo(..))
+import Track exposing (Track, StreamingInfo(..))
 import Task exposing (Task)
 
 

--- a/elm-client/src/Track.elm
+++ b/elm-client/src/Track.elm
@@ -1,0 +1,51 @@
+module Track exposing (..)
+
+
+import Date exposing (Date)
+import Youtube exposing (YoutubeId)
+
+
+type alias TrackId = String
+
+
+type alias Track =
+    { id : TrackId
+    , artist : String
+    , artwork_url : String
+    , title : String
+    , streamingInfo: StreamingInfo
+    , sourceUrl : String
+    , createdAt : Date
+    , liked : Bool
+    , progress : Float
+    , currentTime : Float
+    , error : Bool
+    }
+
+
+type StreamingInfo
+    = Soundcloud StreamUrl
+    | Youtube YoutubeId
+
+
+type alias StreamUrl = String
+
+
+markAsErrored : Track -> Track
+markAsErrored track =
+    { track | error = True }
+
+
+recordProgress : Float -> Float -> Track -> Track
+recordProgress progress currentTime track =
+    { track | progress = progress, currentTime = currentTime }
+
+
+like : Track -> Track
+like track =
+    { track | liked = True }
+
+
+unlike : Track -> Track
+unlike track =
+    { track | liked = False }

--- a/elm-client/src/Tracklist.elm
+++ b/elm-client/src/Tracklist.elm
@@ -1,0 +1,40 @@
+module Tracklist exposing (..)
+
+
+import Dict exposing (Dict)
+import Track exposing (Track, TrackId)
+
+
+type Tracklist =
+    Tracklist (Dict TrackId Track)
+
+
+empty : Tracklist
+empty =
+    Tracklist Dict.empty
+
+
+add : List Track -> Tracklist -> Tracklist
+add newTracks (Tracklist tracklist) =
+    newTracks
+        |> List.map (\track -> ( track.id, track ))
+        |> Dict.fromList
+        |> Dict.union tracklist
+        |> Tracklist
+
+
+update : TrackId -> (Track -> Track) -> Tracklist -> Tracklist
+update trackId fn (Tracklist tracklist) =
+    tracklist
+        |> Dict.update trackId (Maybe.map fn)
+        |> Tracklist
+
+
+get : TrackId -> Tracklist -> Maybe Track
+get trackId (Tracklist tracklist) =
+    Dict.get trackId tracklist
+
+
+getTracks : List TrackId -> Tracklist -> List Track
+getTracks ids (Tracklist tracklist) =
+    List.filterMap (\trackId -> Dict.get trackId tracklist) ids

--- a/elm-client/src/View.elm
+++ b/elm-client/src/View.elm
@@ -6,7 +6,8 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onWithOptions, on)
 import Json.Decode exposing (field)
 import Json.Decode.Extra exposing ((|:))
-import Model exposing (Track, NavigationItem, TrackId)
+import Model exposing (NavigationItem)
+import Track exposing (Track, TrackId)
 
 
 viewGlobalPlayer : msg

--- a/elm-client/tests/ApiTest.elm
+++ b/elm-client/tests/ApiTest.elm
@@ -4,7 +4,7 @@ import Api
 import Date
 import Expect
 import Json.Decode
-import Model exposing (StreamingInfo(..))
+import Track exposing (StreamingInfo(..))
 import String
 import Test exposing (..)
 


### PR DESCRIPTION
These modules encapsulate the logic for manipulating tracks. For
instance using an opaque type hides the fact that Dict is used to store
tracks (even though the API is very similar...).

It lightens the update sub-functions, and mutualizes the common code
between radio and feed.